### PR TITLE
New feature: Reprocess missing lookups after import

### DIFF
--- a/SandboxberryLib/ResultsModel/LookupInfo.cs
+++ b/SandboxberryLib/ResultsModel/LookupInfo.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SandboxberryLib.ResultsModel
+{
+    /// <summary>
+    /// Stores information about lookup relationships and the referenced IDs, sometimes they can't
+    /// be populated during the initial import (when the referenced object doesn't exist yet) and
+    /// need to be reprocessed after
+    /// </summary>
+    public class LookupInfo
+    {
+        public LookupInfo()
+        {
+            this.IdPairs = new List<KeyValuePair<string, string>>();
+        }
+
+        /// <summary>
+        /// API Name of the object that owns the lookup relationship field
+        /// </summary>
+        public String ObjectName { get; set; }
+
+        /// <summary>
+        /// API Name of the object that the lookup relationship field references
+        /// </summary>
+        public String RelatedObjectName { get; set; }
+
+        /// <summary>
+        /// API Name of the lookup relationship field
+        /// </summary>
+        public String FieldName { get; set; }
+
+        /// <summary>
+        /// IDs used by this lookup relationship in the form of key=object, value=referenced object,
+        /// saved during initial processing for reprocessing later
+        /// </summary>
+        public List<KeyValuePair<string,string>> IdPairs { get; set; }
+    }
+}

--- a/SandboxberryLib/SalesforceTasks.cs
+++ b/SandboxberryLib/SalesforceTasks.cs
@@ -166,11 +166,25 @@ namespace SandboxberryLib
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Gets data for all columns of an sobject
+        /// </summary>
         public List<sObject> GetDataFromSObject(string sobjectName, string filter)
         {
-            LoginIfRequired();
             List<string> colNames = RemoveSystemColumns(GetObjectColumns(sobjectName));
             string soql = BuildQuery(sobjectName, colNames, filter);
+            List<sObject> allResults = GetDataFromSObject(sobjectName, colNames, filter);
+            return allResults;
+        }
+
+        /// <summary>
+        /// Gets data for specified columns of an sobject
+        /// </summary>
+        public List<sObject> GetDataFromSObject(string sobjectName, List<string> colList, string filter)
+        {
+            LoginIfRequired();
+            colList = RemoveSystemColumns(colList);
+            string soql = BuildQuery(sobjectName, colList, filter);
 
             bool allResultsReturned = false;
             List<sObject> allResults = new List<sObject>();

--- a/SandboxberryLib/SandboxberryLib.csproj
+++ b/SandboxberryLib/SandboxberryLib.csproj
@@ -58,6 +58,7 @@
       <DependentUpon>Settings.settings</DependentUpon>
     </Compile>
     <Compile Include="RelationMapper.cs" />
+    <Compile Include="ResultsModel\LookupInfo.cs" />
     <Compile Include="ResultsModel\PopulateObjectResult.cs" />
     <Compile Include="ResultsModel\PopulateSandboxResult.cs" />
     <Compile Include="ResultsModel\RowFailInfo.cs" />


### PR DESCRIPTION
I've added a new feature to update lookup relationship fields that get missed during the initial import. For example, if Accounts are imported before Contacts, but Accounts have a Contact lookup, it can't be populated. It ended up being quite similar to what UpdateRecursiveField was already doing, so I've refactored out the code that was shared by both into separate methods as well.